### PR TITLE
Change font to match other text

### DIFF
--- a/facts.html
+++ b/facts.html
@@ -158,7 +158,7 @@
                id="g1105"><g
                  id="g1107"><text
                    id="text1111"
-                   style="font-variant:normal;font-weight:normal;font-size:10.6667px;font-family:'Helvetica Neue';-inkscape-font-specification:HelveticaNeue;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                   style="font-variant:normal;font-weight:normal;font-size:10.6667px;font-family:'Helvetica Neue','Helvetica',Arial,sans-;-inkscape-font-specification:HelveticaNeue;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
                    transform="translate(0,13.629764)"><tspan
                      id="tspan1109"
                      y="0"


### PR DESCRIPTION
It seems the font-family for "Software" was different from the surrounding text, which is why only it appeared with serifs. This makes it consistent with the rest of the sans-serif text.